### PR TITLE
Improved Oakland.js logo appearance on mobile/small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,7 +115,7 @@ h2 {
 .subtitle {
   font-size: 18px;
   text-transform: uppercase;
-  letter-spacing: .16em;  
+  letter-spacing: .16em;
 }
 .content h2 {
   font-style: normal;
@@ -145,7 +145,7 @@ blockquote {
   font-style: italic;
 }
 
-ul, ol, li { 
+ul, ol, li {
   margin: 14px 0;
 }
 
@@ -173,7 +173,7 @@ button {
 
 a {
   color: inherit;
-  text-decoration: none;  
+  text-decoration: none;
 }
 
 p a {
@@ -247,13 +247,13 @@ button:hover, button.transparent:hover {
 .color-a {
   background-color: #f0f0f0;
   color: #90ab89;
-} 
+}
 
 
 .color-c {
   background-color: #222;
   color: #F2F4FF;
-} 
+}
 
 #top-home-section {
   overflow: auto;
@@ -342,7 +342,7 @@ a:hover, button:hover { cursor: pointer; cursor: hand;}
   }
 }
 
-@media only screen and (min-height : 500px) {
+@media only screen and (min-height : 500px) and (min-width: 580px){
   h1 { font-size: 40px; }
   #top-home-image { width: 478px; height: 365px; }
   #top-title { padding-bottom: 15px; font-size: 65px; }
@@ -388,5 +388,5 @@ a:hover, button:hover { cursor: pointer; cursor: hand;}
   .subtitle { margin-bottom: 40px; }
   .community { margin: 40px; }
   .badge img { width: 400px;}
-  
+
 }


### PR DESCRIPTION
It was overflowing on my iPhone. Something had to be done!
Also, Github Atom didn't seem to agree with those trailing spaces, so it auto-removed them.
